### PR TITLE
Allow removal of hosts & reload when config changes

### DIFF
--- a/icinga2/config.sls
+++ b/icinga2/config.sls
@@ -59,18 +59,18 @@
 {{ path }}.conf:
   file.absent:
     - watch_in:
-      - service: icinga2
+      - service: icinga2_service_reload
 {{ path }}/:
   file.absent:
     - watch_in:
-      - service: icinga2
+      - service: icinga2_service_reload
 {%-       else %}
 {{ path }}.conf:
   file.managed:
     - require:
       - file: {{ icinga2.config_dir }}/conf.d/hosts/
     - watch_in:
-      - service: icinga2
+      - service: icinga2_service_reload
     - contents: |
 {{ printconfig("object", "Host", host, hostconf) }}
 
@@ -85,7 +85,7 @@
     - require:
       - file: {{ icinga2.config_dir }}/conf.d/hosts/{{ host }}
     - watch_in:
-      - service: icinga2
+      - service: icinga2_service_reload
     - contents: |
 {{ printconfig("object", "Service", service, serviceconf) }}
 
@@ -102,7 +102,7 @@
 {{ icinga2.config_dir }}/conf.d/hostsgroups.conf:
   file.managed:
     - watch_in:
-      - service: icinga2
+      - service: icinga2_service_reload
     - contents: |
 {%-     for hostgroup, hostgroupconf in conf.hostgroups.items() %}
 {{ printconfig("object", "HostGroup", hostgroup, hostgroupconf) }}
@@ -124,7 +124,7 @@
     - require:
       - file: {{ icinga2.config_dir }}/conf.d/templates
     - watch_in:
-      - service: icinga2
+      - service: icinga2_service_reload
     - contents: |
 {{ printconfig("template", templateinfo["type"], template, templateinfo["conf"]) }}
 
@@ -149,7 +149,7 @@
     - require:
       - file: {{ icinga2.config_dir }}/conf.d/{{ type }}
     - watch_in:
-      - service: icinga2
+      - service: icinga2_service_reload
     - contents: |
 {{ printconfig("apply", applyinfo["type"], apply, applyinfo["conf"], applyto) }}
 

--- a/icinga2/map.jinja
+++ b/icinga2/map.jinja
@@ -24,5 +24,5 @@
     - name: icinga2 feature {{ action }} {{ name }}
     - unless: "icinga2 feature list | grep '^{{ category }} features:.* {{ name }}\\( \\|$\\)'"
     - watch_in:
-      - service: icinga2
+      - service: icinga2_service_restart
 {%- endmacro %}

--- a/icinga2/pgsql-ido.sls
+++ b/icinga2/pgsql-ido.sls
@@ -32,7 +32,7 @@ icinga2ido-pkg:
     - require:
       - pkg: icinga2_pkgs
     - watch_in:
-      - service: icinga2
+      - service: icinga2_service_restart
 
 icinga2ido-config:
   file.managed:
@@ -40,7 +40,7 @@ icinga2ido-config:
     - template: jinja
     - source: salt://icinga2/files/ido-pgsql.conf.jinja
     - watch_in:
-      - service: icinga2
+      - service: icinga2_service_restart
 
 {{ feature('ido-pgsql', True) }}
     - require:

--- a/icinga2/service.sls
+++ b/icinga2/service.sls
@@ -1,6 +1,12 @@
 {% from "icinga2/map.jinja" import icinga2 with context %}
 
-icinga2_service:
+icinga2_service_restart:
   service.running:
     - name: {{ icinga2.service }}
     - enable: True
+
+icinga2_service_reload:
+  service.running:
+    - name: {{ icinga2.service }}
+    - enable: True
+    - reload: True

--- a/pillar.example
+++ b/pillar.example
@@ -82,3 +82,6 @@ icinga2:
               ssh_port: 43
               sla: "24x7"
 
+      # Removes this host from Icinga
+      deprecated.example.com:
+        remove: True


### PR DESCRIPTION
- Allow to remove host definition files again.
- Only reload the service on configuration changes (instead of restarting it).

Tested on Ubuntu 18.04.