### PR TITLE
config: set default values for hosts

### DIFF
--- a/icinga2/config.sls
+++ b/icinga2/config.sls
@@ -54,6 +54,12 @@
 {%-     for host, hostconf in conf.hosts.items() %}
 
 {%-       set path = "{}/conf.d/hosts/{}".format(icinga2.config_dir, host) %}
+{%-       if not hostconf.get('address', False) %}
+{%-         do hostconf.update({'address': host}) %}
+{%-       endif %}
+{%-       if not hostconf.get('import', False) %}
+{%-         do hostconf.update({'import': 'generic-host'}) %}
+{%-       endif %}
 
 {%-       if hostconf['remove'] is sameas true %}
 {{ path }}.conf:

--- a/pillar.example
+++ b/pillar.example
@@ -82,6 +82,12 @@ icinga2:
               ssh_port: 43
               sla: "24x7"
 
+      # Minimalistic, supply only hostname
+      example2.test: {}
+        # sets
+        # address: example2.test
+        # import: generic-host
+
       # Removes this host from Icinga
       deprecated.example.com:
         remove: True


### PR DESCRIPTION
Reduces some boilerplate config in Pillar.

Tested on Ubuntu 18.04.1.