### PR TITLE
FreeBSD support

### DIFF
--- a/icinga2/config.sls
+++ b/icinga2/config.sls
@@ -54,13 +54,22 @@
         }
 {%-endmacro%}
 
-{%- if grains['os_family'] in ['Debian']  %}
+{%- if grains['os_family'] in ['Debian', 'FreeBSD']  %}
 
 ### Begin hosts configuration
 {%-   if conf.hosts is defined %}
 
 {{ icinga2.config_dir }}/conf.d/hosts/:
   file.directory
+
+{%-     if grains['os_family'] in ['FreeBSD']  %}
+{#-       Remove duplicate host entry of Icinga host #}
+{{ icinga2.config_dir }}/conf.d/hosts.conf:
+  file.managed:
+    - contents: ''
+    - watch_in:
+      - service: icinga2_service_reload
+{%-     endif %}
 
 {%-     for host, hostconf in conf.hosts.items() %}
 

--- a/icinga2/defaults.yaml
+++ b/icinga2/defaults.yaml
@@ -22,6 +22,8 @@ icinga2:
   icinga_web2:
     config_dir: /etc/icingaweb2
     modules_dir: /usr/share/icingaweb2/modules
+    user: www-data
+    group: icingaweb2
     db:
       name: icinga2web
       user: icinga2web

--- a/icinga2/icinga-web2-core.sls
+++ b/icinga2/icinga-web2-core.sls
@@ -16,6 +16,10 @@ icinga2-web2:
 {{ feature(name, enable) }}
 {%  endfor %}
 
+icingaweb2-group:
+  group.present:
+    - name: {{ icinga2.icinga_web2.group }}
+
 #Configure automatically Icinga web, avoiding the use of the php wizard
 icinga2web-autoconfigure:
   file.recurse:
@@ -23,15 +27,19 @@ icinga2web-autoconfigure:
     - source: salt://icinga2/files/etc.icingaweb2/
     - template: jinja
     - makedirs: True
-    - user: www-data
-    - group: icingaweb2
+    - user: {{ icinga2.icinga_web2.user }}
+    - group: {{ icinga2.icinga_web2.group }}
     - dir_mode: 750
     - file_mode: 644
+    - require:
+      - group: icingaweb2-group
 
 icinga2web-autoconfigure-finalize:
   file.symlink:
     - name: "{{ icinga2.icinga_web2.config_dir }}/enabledModules/monitoring"
     - target: "{{ icinga2.icinga_web2.modules_dir }}/monitoring"
     - makedirs: True
-    - user: www-data
-    - group:  icingaweb2
+    - user: {{ icinga2.icinga_web2.user }}
+    - group: {{ icinga2.icinga_web2.group }}
+    - require:
+      - group: icingaweb2-group

--- a/icinga2/osfamilymap.yaml
+++ b/icinga2/osfamilymap.yaml
@@ -21,3 +21,10 @@ FreeBSD:
     # In FreeBSD IDO is included in the icinga2 package.
     pkg: False
     schema_path: /usr/local/share/icinga2-ido-pgsql/schema/pgsql.sql
+  notification:
+    xmpp:
+      pkg: py36-slixmpp
+      python_executable: python3.6
+      ca_file: /usr/local/share/certs/ca-root-nss.crt
+      additional_pkgs:
+        - ca_root_nss

--- a/icinga2/osfamilymap.yaml
+++ b/icinga2/osfamilymap.yaml
@@ -5,3 +5,19 @@ FreeBSD:
   icinga_web2:
     config_dir: /usr/local/etc/icingaweb2
     modules_dir: /usr/local/www/icingaweb2/modules
+    user: www
+    pkgs:
+      - icingaweb2
+    required_pkgs:
+{%- set phpng_version = salt['pillar.get']('php:ng:version', '7.2')|string %}
+{%- set freebsd_phpng_version = phpng_version.replace('.', '') %}
+      - mod_php{{ freebsd_phpng_version }}
+      - php{{ freebsd_phpng_version }}
+      - php{{ freebsd_phpng_version }}-gd
+      - php{{ freebsd_phpng_version }}-intl
+      - php{{ freebsd_phpng_version }}-pgsql
+      - php{{ freebsd_phpng_version }}-gd
+  ido:
+    # In FreeBSD IDO is included in the icinga2 package.
+    pkg: False
+    schema_path: /usr/local/share/icinga2-ido-pgsql/schema/pgsql.sql

--- a/icinga2/pgsql-ido.sls
+++ b/icinga2/pgsql-ido.sls
@@ -26,6 +26,7 @@ debconf_pgsql_ido:
       - pkg: icinga2ido-pkg
 {% endif %}
 
+{% if icinga2.ido.pkg %}
 icinga2ido-pkg:
   pkg.installed:
     - name: "{{ icinga2.ido.pkg }}"
@@ -33,6 +34,7 @@ icinga2ido-pkg:
       - pkg: icinga2_pkgs
     - watch_in:
       - service: icinga2_service_restart
+{% endif %}
 
 icinga2ido-config:
   file.managed:
@@ -44,7 +46,9 @@ icinga2ido-config:
 
 {{ feature('ido-pgsql', True) }}
     - require:
+{% if icinga2.ido.pkg %}
       - pkg: icinga2ido-pkg
+{% endif %}
       - file: icinga2ido-config
 
 is-icinga2ido-password-set:

--- a/icinga2/postgresql-client.sls
+++ b/icinga2/postgresql-client.sls
@@ -1,6 +1,10 @@
 {% from "icinga2/map.jinja" import icinga2 with context %}
 
-{% if salt['pillar.get']('icinga2:postgres:use_formula', False) %}
+{% set dependent_pkg = "icinga2ido-pkg" if icinga2.ido.pkg else "icinga2_pkgs" %}
+
+{#- In FreeBSD, icinga2 has a dependency on postgresqlXY-client #}
+{%- if salt['grains.get']('os_family') != 'FreeBSD' %}
+{%-   if salt['pillar.get']('icinga2:postgres:use_formula', False) %}
 include:
   - postgres.client
 
@@ -8,11 +12,12 @@ extend:
   postgresql-client-libs:
     pkg:
     - require_in:
-      - pkg: icinga2ido-pkg
-{% else %}
+      - pkg: {{ dependent_pkg }}
+{%-   else %}
 postgresql_packages_for_icinga_ido:
   pkg.installed:
     - pkgs: {{ icinga2.postgresql_pkgs }}
     - require_in:
-      - pkg: icinga2ido-pkg
-{% endif %}
+      - pkg: {{ dependent_pkg }}
+{%-   endif %}
+{%- endif %}


### PR DESCRIPTION
- Adjusted some names, paths and package lists.
- Fixed a bug on FreeBSD regarding a host duplicate.
- FreeBSD support for `notifications.xmpp`

Tested on
- FreeBSD 11.2
- Ubuntu 18.04