### PR TITLE
Dropped invalid parameter 'createuser'

### DIFF
--- a/icinga2/icinga-web2-database.sls
+++ b/icinga2/icinga-web2-database.sls
@@ -14,7 +14,6 @@ icinga2web-db-setup:
     - password: "{{ icinga2.icinga_web2.db.password }}"
     - createdb: True
     - createroles: True
-    - createuser: True
     - inherit: True
     - login: True
     # Necessary as of PostgreSQL 10

--- a/icinga2/pgsql-ido.sls
+++ b/icinga2/pgsql-ido.sls
@@ -64,7 +64,6 @@ icinga2ido-db-setup:
     - password: "{{ icinga2.ido.db.password }}"
     - createdb: True
     - createroles: True
-    - createuser: True
     - inherit: True
     - login: True
     # Necessary as of PostgreSQL 10


### PR DESCRIPTION
Solves this error:

> ERROR executing 'state.highstate': 'createuser' is an invalid keyword argument for 'postgres_user.present'

Tested on FreeBSD 11.2.