### PR TITLE
fix(freebsd): FreeBSD user and group are named 'icinga'

### DIFF
--- a/icinga2/osfamilymap.yaml
+++ b/icinga2/osfamilymap.yaml
@@ -1,5 +1,7 @@
 Debian: {}
 FreeBSD:
+  user: icinga
+  group: icinga
   configure_repositories: False
   config_dir: /usr/local/etc/icinga2
   icinga_web2:


### PR DESCRIPTION
FreeBSD uses different user and group.

Tested on FreeBSD 11.2.