### PR TITLE
Fix repository

### DIFF
--- a/icinga2/defaults.yaml
+++ b/icinga2/defaults.yaml
@@ -12,6 +12,7 @@ icinga2:
     - postgresql-client
   service: icinga2
   configure_repositories: True
+  enable_debian_backports: True
   ido:
     db:
       name: icinga

--- a/icinga2/defaults.yaml
+++ b/icinga2/defaults.yaml
@@ -12,7 +12,7 @@ icinga2:
     - postgresql-client
   service: icinga2
   configure_repositories: True
-  enable_debian_backports: True
+  enable_debian_backports: False
   ido:
     db:
       name: icinga

--- a/icinga2/repositories.sls
+++ b/icinga2/repositories.sls
@@ -12,7 +12,7 @@ debmon:
   pkgrepo.absent: []
 
 # Icinga require packages from debian backports
-{% if icinga2.get('enable_debian_backports', True) %}
+{% if icinga2.enable_debian_backports %}
 icinga_repo_debian_backports:
   pkgrepo.managed:
     - humanname: debian_backports

--- a/icinga2/repositories.sls
+++ b/icinga2/repositories.sls
@@ -1,3 +1,5 @@
+{% from "icinga2/map.jinja" import icinga2 with context %}
+
 {% if grains.os == 'Debian' %}
 icinga_repo_required_packages:
   pkg.installed:
@@ -8,6 +10,15 @@ icinga_repo_required_packages:
 # The old repo's name
 debmon:
   pkgrepo.absent: []
+
+# Icinga require packages from debian backports
+{% if icinga2.get('enable_debian_backports', True) %}
+icinga_repo_debian_backports:
+  pkgrepo.managed:
+    - humanname: debian_backports
+    - name: deb http://deb.debian.org/debian {{ grains['lsb_distrib_codename'] }}-backports main
+    - file: /etc/apt/sources.list.d/backports.list
+{% endif %}
 {% endif %}
 
 icinga_repo:

--- a/icinga2/repositories.sls
+++ b/icinga2/repositories.sls
@@ -1,4 +1,4 @@
-{% if grains['os'] == 'Debian' %}
+{% if grains.os == 'Debian' %}
 icinga_repo_required_packages:
   pkg.installed:
     - name: python-apt
@@ -13,6 +13,6 @@ debmon:
 icinga_repo:
   pkgrepo.managed:
     - humanname: icinga_official
-    - name: deb http://packages.icinga.org/ubuntu icinga-{{ grains['lsb_distrib_codename'] }} main
+    - name: deb http://packages.icinga.org/{{ grains.os|lower }} icinga-{{ grains['lsb_distrib_codename'] }} main
     - file: /etc/apt/sources.list.d/icinga.list
     - key_url: http://packages.icinga.org/icinga.key

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,10 @@
 icinga2:
   lookup:  # See defaults.yaml and map.jinja for a better overview
     service: icinga2
+    # To use the icinga repo, on some Debian version, you have to enable
+    # debian-backports, like Debian Stretch.
+    configure_repositories: True
+    enable_debian_backports: False
     pkgs:
       - icinga2
       #- nagios-nrpe-plugin


### PR DESCRIPTION
icinga2/repositories.sls didn't work with debian, because there was ubuntu hard coded.
In Debian Stretch, debian-backports must be enabled for the packages from the icinga repository. I added a flag for it.